### PR TITLE
refactor: simplify test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ as_conversions = "deny"
 [workspace.dependencies]
 assert_matches = "1.5.0"
 axum = "0.6.12"
-hyper = "0.13.9"
+hyper = "1.2.0"
+pretty_assertions = "1.4.0"
 rstest = "0.17.0"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-assert_matches.workspace = true
 axum.workspace = true
 hyper.workspace = true
 serde.workspace = true
@@ -18,6 +17,7 @@ starknet_api.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
+pretty_assertions.workspace = true
 rstest.workspace = true
 tokio.workspace = true
-

--- a/crates/gateway/src/gateway_test.rs
+++ b/crates/gateway/src/gateway_test.rs
@@ -1,9 +1,12 @@
 use crate::gateway::add_transaction;
-use axum::{body::HttpBody, response::IntoResponse};
+use axum::{
+    body::{Bytes, HttpBody},
+    response::{IntoResponse, Response},
+};
+use pretty_assertions::assert_str_eq;
 use rstest::rstest;
 use starknet_api::external_transaction::ExternalTransaction;
 use std::fs::File;
-use std::io::BufReader;
 
 // TODO(Ayelet): Replace the use of the JSON files with generated instances, then serialize these
 // into JSON for testing.
@@ -16,13 +19,15 @@ use std::io::BufReader;
 #[case("./src/json_files_for_testing/invoke_v3.json", "INVOKE")]
 #[tokio::test]
 async fn test_add_transaction(#[case] json_file_path: &str, #[case] expected_response: &str) {
-    let file = File::open(json_file_path).unwrap();
-    let reader = BufReader::new(file);
-    let transaction: ExternalTransaction = serde_json::from_reader(reader).unwrap();
-    let response = add_transaction(transaction.into()).await.into_response();
-    let response_bytes = response.into_body().collect().await.unwrap().to_bytes();
-    assert_eq!(
-        &String::from_utf8(response_bytes.to_vec()).unwrap(),
-        expected_response
-    );
+    let json_file = File::open(json_file_path).unwrap();
+    let tx: ExternalTransaction = serde_json::from_reader(json_file).unwrap();
+
+    let response = add_transaction(tx.into()).await.into_response();
+    let response_bytes = &to_bytes(response).await;
+
+    assert_str_eq!(&String::from_utf8_lossy(response_bytes), expected_response);
+}
+
+async fn to_bytes(res: Response) -> Bytes {
+    res.into_body().collect().await.unwrap().to_bytes()
 }


### PR DESCRIPTION
refactor test:
- dont need to pass through BufReader
- extract cast to bytes into test util
- cast string lossy to save unwrap
- spacing
- use better str compare

chore:
- `hyper` version is way too old, bump it.
- add `pretty_assertions` for nicer diff.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/26)
<!-- Reviewable:end -->
