### PR TITLE
feat: add routes test (semi-integration test)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,6 +2200,7 @@ dependencies = [
  "starknet_api",
  "thiserror",
  "tokio",
+ "tower",
  "validator",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ starknet_api = { git = "https://github.com/starkware-libs/starknet-api.git", rev
 papyrus_config = "0.3.0"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
+tower = "0.4.13"
 validator = "0.12"
-

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -12,11 +12,12 @@ workspace = true
 axum.workspace = true
 clap.workspace = true
 hyper.workspace = true
+papyrus_config.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 starknet_api.workspace = true
 thiserror.workspace = true
-papyrus_config.workspace = true
+tower.workspace = true
 validator.workspace = true
 
 [dev-dependencies]

--- a/crates/gateway/tests/routing_test.rs
+++ b/crates/gateway/tests/routing_test.rs
@@ -1,0 +1,45 @@
+use axum::body::{Body, Bytes, HttpBody};
+use axum::http::{Request, StatusCode};
+use pretty_assertions::assert_str_eq;
+use rstest::rstest;
+use starknet_gateway::gateway::app;
+use std::fs;
+use tower::ServiceExt;
+
+// TODO(Ayelet): Replace the use of the JSON files with generated instances, then serialize these
+// into JSON for testing.
+#[rstest]
+#[case("./src/json_files_for_testing/declare_v3.json", "DECLARE")]
+#[case(
+    "./src/json_files_for_testing/deploy_account_v3.json",
+    "DEPLOY_ACCOUNT"
+)]
+#[case("./src/json_files_for_testing/invoke_v3.json", "INVOKE")]
+#[tokio::test]
+async fn test_routes(#[case] json_file_path: &str, #[case] expected_response: &str) {
+    let tx_json = fs::read_to_string(json_file_path).unwrap();
+    let request = Request::post("/add_transaction")
+        .header("content-type", "application/json")
+        .body(Body::from(tx_json))
+        .unwrap();
+
+    let response = check_request(request, StatusCode::OK).await;
+
+    assert_str_eq!(expected_response, String::from_utf8_lossy(&response));
+}
+
+#[tokio::test]
+#[should_panic]
+// FIXME: Currently is_alive is not implemented, fix this once it is implemented.
+async fn test_is_alive() {
+    let request = Request::get("/is_alive").body(Body::empty()).unwrap();
+    // Status code doesn't matter, this panics ATM.
+    check_request(request, StatusCode::default()).await;
+}
+
+async fn check_request(request: Request<Body>, status_code: StatusCode) -> Bytes {
+    let response = app().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), status_code);
+
+    response.into_body().collect().await.unwrap().to_bytes()
+}


### PR DESCRIPTION
- tests that routes behave the way we expect, shouldn't have too much logic here, just test status codes and return values. Proper integration/flow tests will be in their own testing file.
- add `tower` dependency that `axum` uses in order to simulate an HTTP request via the `oneshot` call: this simulates the HTTP request without having to spin up an actual server and perform IO.
- Currently add_transaction test is identical to the one in gateway_test.rs, but they'll diverge once real logic kicks in. At that point the routes test will only test for success codes in basic scenarios.
- is_alive is currently just a dummy test, since it isn't implemented yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/28)
<!-- Reviewable:end -->
