### PR TITLE
feat: add task executor trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,6 +3246,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet_task_executor"
+version = "0.0.0"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,13 @@
 [workspace]
+members = [
+    "crates/gateway",
+    "crates/mempool",
+    "crates/mempool_types",
+    "crates/mempool_node",
+    "crates/mempool_infra",
+    "crates/task_executor",
+]
 resolver = "2"
-members = ["crates/gateway", "crates/mempool", "crates/mempool_types", "crates/mempool_node", "crates/mempool_infra"]
 
 [workspace.package]
 version = "0.0.0"
@@ -39,7 +46,7 @@ serde_json = "1.0"
 # TODO(Arni, 1/5/2024): Use a fixed version once the StarkNet API is stable.
 starknet_api = { git = "https://github.com/starkware-libs/starknet-api.git", rev = "0f49f20a" }
 thiserror = "1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.37.0", features = ["full"] }
 tower = "0.4.13"
 url = "2.5.0"
 validator = "0.12"

--- a/crates/task_executor/Cargo.toml
+++ b/crates/task_executor/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "starknet_task_executor"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true

--- a/crates/task_executor/src/executor.rs
+++ b/crates/task_executor/src/executor.rs
@@ -1,0 +1,24 @@
+use std::future::Future;
+
+/// An abstraction for executing tasks, suitable for both CPU-bound and I/O-bound operations.
+pub trait TaskExecutor {
+    type SpawnBlockingError;
+    type SpawnError;
+
+    /// Offloads a blocking task, _ensuring_ the async event loop remains responsive.
+    /// It accepts a function that executes a blocking operation and returns a result.
+    fn spawn_blocking<F, T>(
+        &self,
+        task: F,
+    ) -> impl Future<Output = Result<T, Self::SpawnBlockingError>> + Send
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static;
+
+    /// Offloads a non-blocking task asynchronously.
+    /// It accepts a future representing an asynchronous operation and returns a result.
+    fn spawn<F, T>(&self, task: F) -> impl Future<Output = Result<T, Self::SpawnError>> + Send
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static;
+}

--- a/crates/task_executor/src/lib.rs
+++ b/crates/task_executor/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod executor;


### PR DESCRIPTION
Proper usage example via tokio in upcoming PR, here is an abstract one:

```rust
 async fn initiates_a_cpu_bound_task() -> Result<(), Box<dyn std::error::Error>>{
    let executor = SomethingThatImplementsTaskExecutor::new();
    let derp = "DERP".to_string();
    let res = executor.spawn_blocking(move || {
	// Simulate blocking cpu computation
	let derp_world += derp + " world"
	// return the result of the computation
	derp_world
    }).await?;

    assert_eq!(res.as_str(), "DERP world");

    Ok(())
 }
```

```rust
 async fn initiates_an_io_bound_task() -> Result<(), Box<dyn std::error::Error>>{
    let executor = SomethingThatImplementsTaskExecutor::new();
    let derp = "DERP";
    let res = executor.spawn(async move || {
	tokio::time::sleep(tokio::time::Duration::from_secs(1)).await; // async sleep.
	println!("{derp}");
	derp
    }).await?;

    assert_eq!(res.as_str(), "DERP");

    Ok(())
}
```

commit-id:c6d2cb55

---

**Stack**:
- #51
- #50
- #49 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*