### PR TITLE
feat: add tokio executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,6 +3268,10 @@ dependencies = [
 [[package]]
 name = "starknet_task_executor"
 version = "0.0.0"
+dependencies = [
+ "tokio",
+ "tokio-test",
+]
 
 [[package]]
 name = "static_assertions"
@@ -3496,6 +3522,30 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ serde_json = "1.0"
 starknet_api = { git = "https://github.com/starkware-libs/starknet-api.git", rev = "0f49f20a" }
 thiserror = "1.0"
 tokio = { version = "1.37.0", features = ["full"] }
+tokio-test = "0.4.4"
 tower = "0.4.13"
 url = "2.5.0"
 validator = "0.12"

--- a/crates/task_executor/Cargo.toml
+++ b/crates/task_executor/Cargo.toml
@@ -5,5 +5,11 @@ edition.workspace = true
 repository.workspace = true
 license.workspace = true
 
+[dependencies]
+tokio.workspace = true
+
+[dev-dependencies]
+tokio-test.workspace = true
+
 [lints]
 workspace = true

--- a/crates/task_executor/src/lib.rs
+++ b/crates/task_executor/src/lib.rs
@@ -1,1 +1,5 @@
+//! This crate contains the async and blocking tasks Executor, which is temporarily placed here.
+//! It will likely be moved to `mempool_infra` or some other infra crate in the future.
+
 pub mod executor;
+pub mod tokio_executor;

--- a/crates/task_executor/src/tokio_executor.rs
+++ b/crates/task_executor/src/tokio_executor.rs
@@ -1,0 +1,126 @@
+use std::future::Future;
+
+use tokio::runtime::Handle;
+
+use crate::executor::TaskExecutor;
+
+#[derive(Clone)]
+pub struct TokioExecutor {
+    // Invariant: the handle must remain private to ensure all tasks spawned via this
+    // executor originate from the same handle, maintaining control and consistency.
+    handle: Handle,
+}
+
+impl TokioExecutor {
+    pub fn new(handle: Handle) -> Self {
+        Self { handle }
+    }
+
+    /// Spawns a task and returns a `JoinHandle`.
+    ///
+    /// This method is needed to allow tasks to be tracked and managed through a `JoinHandle`,
+    /// enabling control over task lifecycle such as awaiting completion, cancellation, or checking
+    /// results. It should be used only when the caller needs to manage the task directly, which is
+    /// essential both in testing scenarios and in the actual system `main` function.
+    /// Note: In most cases, where task management is not necessary, the `spawn` or
+    /// `spawn_blocking` methods should be preferred.
+    ///
+    /// # Example
+    /// ```
+    /// use starknet_task_executor::tokio_executor::TokioExecutor;
+    /// use tokio::runtime::Handle;
+    /// use tokio::sync::oneshot;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let runtime = Handle::current();
+    ///     let executor = TokioExecutor::new(runtime);
+    ///
+    ///     // Create a oneshot channel to simulate a task waiting for a signal.
+    ///     let (_will_not_send, await_signal_that_wont_come) = oneshot::channel::<()>();
+    ///
+    ///     // Spawn a task that waits for the signal (which we will not send).
+    ///     let handle = executor.spawn_with_handle(async move {
+    ///         await_signal_that_wont_come.await.ok();
+    ///     });
+    ///
+    ///     // Abort the task before sending the signal.
+    ///     handle.abort();
+    ///
+    ///     assert!(handle.await.unwrap_err().is_cancelled());
+    /// }
+    /// ```
+    pub fn spawn_with_handle<F>(&self, future: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.handle.spawn(future)
+    }
+}
+
+impl TaskExecutor for TokioExecutor {
+    type SpawnBlockingError = tokio::task::JoinError;
+    type SpawnError = tokio::task::JoinError;
+
+    /// Spawns a task that may block, on a dedicated thread, preventing disruption of the async
+    /// runtime.
+
+    /// # Example
+    ///
+    /// ```
+    /// use starknet_task_executor::executor::TaskExecutor;
+    /// use starknet_task_executor::tokio_executor::TokioExecutor;
+    ///
+    /// tokio_test::block_on(async {
+    ///     let executor = TokioExecutor::new(tokio::runtime::Handle::current());
+    ///     let task = || {
+    ///         // Simulate CPU-bound work (sleep/Duration from std and not tokio!).
+    ///         std::thread::sleep(std::time::Duration::from_millis(100));
+    ///         "FLOOF"
+    ///     };
+    ///     let result = executor.spawn_blocking(task).await;
+    ///     assert_eq!(result.unwrap(), "FLOOF");
+    /// });
+    /// ```
+    fn spawn_blocking<F, T>(
+        &self,
+        task: F,
+    ) -> impl Future<Output = Result<T, Self::SpawnBlockingError>> + Send
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        self.handle.spawn_blocking(task)
+    }
+
+    /// Executes a async, non-blocking task.
+    ///
+    /// Note: If you need to manage the task directly through a `JoinHandle`, use
+    /// [`Self::spawn_with_handle`] instead.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use starknet_task_executor::{
+    ///   tokio_executor::TokioExecutor, executor::TaskExecutor
+    /// };
+    ///
+    /// tokio_test::block_on(async {
+    ///     let executor = TokioExecutor::new(tokio::runtime::Handle::current());
+    ///     let future = async {
+    ///         // Simulate IO-bound work (sleep/Duration from tokio!).
+    ///         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    ///         "HOPALA"
+    ///     };
+    ///     let result = executor.spawn(future).await;
+    ///     assert_eq!(result.unwrap(), "HOPALA");
+    /// });
+    fn spawn<F, T>(&self, task: F) -> impl Future<Output = Result<T, Self::SpawnError>> + Send
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        self.handle.spawn(task)
+    }
+}


### PR DESCRIPTION
- Add a naive task executor, currently utilizing tokio for both CPU and IO
tasks.
- Tokio promises two separate threadpools for spawn_blocking and spawn,
  which should prevent starvation, but not sure how this affects
  latency.
- `spawn_with_handle` is needed because of the generality of
  `TaskExecutor` trait and since rust doesn't have
  reflection/downcasting: tokio's spawn return value is `JoinHandle`,
  which implements `Future`, but one cannot get a JoinHandle from a
  `impl Future` typed object, hence a separate method is needed.
- More tests coming up.

  TODO: when we start managing tokio runtimes explicitly, we might
  have to modify the executor to be aware of the runtime.

  TODO 2: if we need to throttle cpu-bound tasks, see semaphore
  implementation of this commit on the branch
  gilad/executor-semaphore-version

commit-id:b61022a4

---

**Stack**:
- #174
- #173
- #172
- #51
- #50 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*