### PR TITLE
feat: implement from for priority queue

### DIFF
--- a/crates/mempool/src/priority_queue.rs
+++ b/crates/mempool/src/priority_queue.rs
@@ -2,13 +2,11 @@
 #[path = "priority_queue_test.rs"]
 pub mod priority_queue_test;
 
-use std::{cmp::Ordering, collections::BTreeSet};
-
 use starknet_api::{
     internal_transaction::InternalTransaction,
     transaction::{DeclareTransaction, DeployAccountTransaction, InvokeTransaction, Tip},
 };
-
+use std::{cmp::Ordering, collections::BTreeSet};
 // Assumption: for the MVP only one transaction from the same contract class can be in the mempool
 // at a time. When this changes, saving the transactions themselves on the queu might no longer be
 // appropriate, because we'll also need to stores transactions without indexing them. For example,
@@ -28,7 +26,15 @@ impl PriorityQueue {
     }
 }
 
-#[derive(Clone, Debug, derive_more::Deref)]
+impl From<Vec<InternalTransaction>> for PriorityQueue {
+    fn from(transactions: Vec<InternalTransaction>) -> Self {
+        PriorityQueue(BTreeSet::from_iter(
+            transactions.into_iter().map(PQTransaction),
+        ))
+    }
+}
+
+#[derive(Clone, Debug, derive_more::Deref, derive_more::From)]
 pub struct PQTransaction(pub InternalTransaction);
 
 impl PQTransaction {


### PR DESCRIPTION
Implements From function for PriorityQueue.
gets a vector of InternalTransactions and adds them to a PriorityQueue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/57)
<!-- Reviewable:end -->
