### PR TITLE
fix: install cargo udeps differently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,15 +69,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
-        name: "Rust Toolchain Setup"
         with:
           toolchain: nightly-2024-01-12
       - uses: Swatinem/rust-cache@v2
-        id: "cache-cargo"
-      - if: ${{ steps.cache-cargo.outputs.cache-hit != 'true' }}
-        name: "Download and run cargo-udeps"
-        run: |
-          wget -O - -c https://github.com/est31/cargo-udeps/releases/download/v0.1.45/cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu.tar.gz | tar -xz
-          cargo-udeps-*/cargo-udeps udeps
-        env:
-          RUSTUP_TOOLCHAIN: nightly-2024-01-12
+      - name: Install udeps, should be cached unless `Cargo.{toml.lock}` or this workflow change
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-udeps
+      - name: Run udeps (detect unused dependencies)
+        run: cargo udeps


### PR DESCRIPTION
- instead of compiling from source, use a cached `cargo install` github action (which appears to be cached by default!), and then run udeps from cargo.
- this is the recommended installation method from udeps' readme.
- motivation: Previous method of installation seemed to hit compilation errors [here] (https://reviewable.io/reviews/starkware-libs/mempool/42#-), that weren't reproducible when running through `cargo udeps`.

- NOTE: The github action used for cargo-install only has ~100 stars, which isn't a lot, but I found a few well-used projects that use them, like tokio-rs/prost and wez/wezterm, so it's probably OK.

- ALTERNATIVE: switching from udeps to [machete](https://github.com/bnjbvr/cargo-machete). The cairo team did and they're pleased with the results.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/82)
<!-- Reviewable:end -->
