### PR TITLE
chore: create integration tests crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,7 +3402,6 @@ dependencies = [
  "axum",
  "blockifier",
  "cairo-lang-starknet-classes",
- "hyper",
  "mempool_infra",
  "papyrus_config",
  "pretty_assertions",
@@ -3430,6 +3429,23 @@ dependencies = [
  "pretty_assertions",
  "rstest",
  "starknet_api",
+ "starknet_mempool_types",
+ "tokio",
+]
+
+[[package]]
+name = "starknet_mempool_integration_tests"
+version = "0.0.0"
+dependencies = [
+ "axum",
+ "hyper",
+ "mempool_infra",
+ "pretty_assertions",
+ "reqwest",
+ "rstest",
+ "starknet_api",
+ "starknet_gateway",
+ "starknet_mempool",
  "starknet_mempool_types",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/starknet_sierra_compile",
     "crates/task_executor",
     "crates/test_utils",
+    "crates/tests-integration",
 ]
 resolver = "2"
 

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -15,7 +15,6 @@ testing = []
 axum.workspace = true
 blockifier.workspace = true
 cairo-lang-starknet-classes.workspace = true
-hyper.workspace = true
 mempool_infra = { path = "../mempool_infra", version = "0.0" }
 papyrus_config.workspace = true
 reqwest.workspace = true

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod config;
 pub mod errors;
 pub mod gateway;
-pub mod gateway_client;
 pub mod rpc_objects;
 pub mod rpc_state_reader;
 pub mod starknet_api_test_utils;

--- a/crates/tests-integration/Cargo.toml
+++ b/crates/tests-integration/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "starknet_mempool_integration_tests"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+axum.workspace = true
+hyper.workspace = true
+reqwest.workspace = true
+starknet_api.workspace = true
+starknet_gateway = { path = "../gateway", version = "0.0" }
+
+[dev-dependencies]
+mempool_infra = { path = "../mempool_infra", version = "0.0" }
+pretty_assertions.workspace = true
+rstest.workspace = true
+starknet_mempool = { path = "../mempool", version = "0.0" }
+starknet_mempool_types = { path = "../mempool_types", version = "0.0" }
+tokio.workspace = true

--- a/crates/tests-integration/src/integration_test_utils.rs
+++ b/crates/tests-integration/src/integration_test_utils.rs
@@ -5,11 +5,7 @@ use hyper::StatusCode;
 use reqwest::{Client, Response};
 use starknet_api::external_transaction::ExternalTransaction;
 use starknet_api::transaction::TransactionHash;
-
-use crate::errors::GatewayError;
-use crate::starknet_api_test_utils::external_tx_to_json;
-
-pub type GatewayResult<T> = Result<T, GatewayError>;
+use starknet_gateway::starknet_api_test_utils::external_tx_to_json;
 
 /// A test utility client for interacting with a gateway server.
 pub struct GatewayClient {

--- a/crates/tests-integration/src/lib.rs
+++ b/crates/tests-integration/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod integration_test_utils;

--- a/crates/tests-integration/tests/end_to_end_test.rs
+++ b/crates/tests-integration/tests/end_to_end_test.rs
@@ -10,10 +10,10 @@ use starknet_gateway::config::{
     StatelessTransactionValidatorConfig,
 };
 use starknet_gateway::gateway::Gateway;
-use starknet_gateway::gateway_client;
 use starknet_gateway::starknet_api_test_utils::invoke_tx;
 use starknet_gateway::state_reader_test_utils::test_state_reader_factory;
 use starknet_mempool::mempool::Mempool;
+use starknet_mempool_integration_tests::integration_test_utils::GatewayClient;
 use starknet_mempool_types::mempool_types::{
     BatcherToMempoolChannels, BatcherToMempoolMessage, GatewayNetworkComponent,
     GatewayToMempoolMessage, MempoolInput, MempoolNetworkComponent, MempoolToBatcherMessage,
@@ -109,7 +109,7 @@ async fn test_end_to_end() {
 
     // Send a transaction.
     let external_tx = invoke_tx();
-    let gateway_client = gateway_client::GatewayClient::new(socket_addr);
+    let gateway_client = GatewayClient::new(socket_addr);
     gateway_client.assert_add_tx_success(&external_tx).await;
 
     // Initialize Mempool.


### PR DESCRIPTION
- move e2e test into crate
- rename gateway client into a test utils module in the crate + remove
  stale typedef.

commit-id:8948e34d

---

**Stack**:
- #174
- #173
- #172 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*