### PR TITLE
feat: add IntegrationTestSetup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5358,6 +5358,7 @@ dependencies = [
  "starknet_mempool",
  "starknet_mempool_infra",
  "starknet_mempool_types",
+ "starknet_task_executor",
  "tokio",
 ]
 

--- a/crates/gateway/src/gateway.rs
+++ b/crates/gateway/src/gateway.rs
@@ -25,7 +25,7 @@ pub mod gateway_test;
 pub type GatewayResult<T> = Result<T, GatewayError>;
 
 pub struct Gateway {
-    config: GatewayConfig,
+    pub config: GatewayConfig,
     app_state: AppState,
 }
 
@@ -71,8 +71,6 @@ impl Gateway {
             .route("/is_alive", get(is_alive))
             .route("/add_tx", post(add_tx))
             .with_state(self.app_state)
-        // TODO: when we need to configure the router, like adding banned ips, add it here via
-        // `with_state`.
     }
 }
 

--- a/crates/mempool_infra/src/component_client.rs
+++ b/crates/mempool_infra/src/component_client.rs
@@ -3,7 +3,6 @@ use tokio::sync::mpsc::{channel, Sender};
 
 use crate::component_definitions::ComponentRequestAndResponseSender;
 
-#[derive(Clone)]
 pub struct ComponentClient<Request, Response>
 where
     Request: Send + Sync,
@@ -29,6 +28,18 @@ where
         self.tx.send(request_and_res_tx).await.expect("Outbound connection should be open.");
 
         res_rx.recv().await.expect("Inbound connection should be open.")
+    }
+}
+
+// Can't derive because derive forces the generics to also be `Clone`, which we prefer not to do
+// since it'll require transactions to be cloneable.
+impl<Request, Response> Clone for ComponentClient<Request, Response>
+where
+    Request: Send + Sync,
+    Response: Send + Sync,
+{
+    fn clone(&self) -> Self {
+        Self { tx: self.tx.clone() }
     }
 }
 

--- a/crates/mempool_types/src/errors.rs
+++ b/crates/mempool_types/src/errors.rs
@@ -1,7 +1,7 @@
 use starknet_api::transaction::TransactionHash;
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 pub enum MempoolError {
     #[error("Duplicate transaction, of hash: {tx_hash}")]
     DuplicateTransaction { tx_hash: TransactionHash },

--- a/crates/tests-integration/Cargo.toml
+++ b/crates/tests-integration/Cargo.toml
@@ -12,12 +12,13 @@ workspace = true
 axum.workspace = true
 reqwest.workspace = true
 starknet_api.workspace = true
-starknet_gateway = { path = "../gateway", version = "0.0" }
+starknet_gateway = { path = "../gateway", version = "0.0", features = ["testing"] }
+starknet_mempool = { path = "../mempool", version = "0.0" }
+starknet_mempool_types = { path = "../mempool_types", version = "0.0" }
+starknet_task_executor = { path = "../task_executor", version = "0.0" }
+tokio.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
 rstest.workspace = true
-starknet_mempool = { path = "../mempool", version = "0.0" }
 starknet_mempool_infra = { path = "../mempool_infra", version = "0.0" }
-starknet_mempool_types = { path = "../mempool_types", version = "0.0" }
-tokio.workspace = true

--- a/crates/tests-integration/src/integration_test_setup.rs
+++ b/crates/tests-integration/src/integration_test_setup.rs
@@ -1,0 +1,90 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use starknet_api::external_transaction::ExternalTransaction;
+use starknet_api::transaction::TransactionHash;
+use starknet_gateway::config::GatewayNetworkConfig;
+use starknet_gateway::errors::GatewayError;
+use starknet_mempool::communication::create_mempool_server;
+use starknet_mempool::mempool::Mempool;
+use starknet_mempool_types::communication::{
+    MempoolClient, MempoolClientImpl, MempoolRequestAndResponseSender,
+};
+use starknet_mempool_types::mempool_types::ThinTransaction;
+use starknet_task_executor::executor::TaskExecutor;
+use starknet_task_executor::tokio_executor::TokioExecutor;
+use tokio::runtime::Handle;
+use tokio::sync::mpsc::channel;
+use tokio::task::JoinHandle;
+
+use crate::integration_test_utils::{create_gateway, GatewayClient};
+
+pub struct IntegrationTestSetup {
+    pub task_executor: TokioExecutor,
+    pub gateway_client: GatewayClient,
+    // TODO(MockBatcher).
+    pub batcher_mempool_client: MempoolClientImpl,
+
+    pub gateway_handle: JoinHandle<()>,
+    pub mempool_handle: JoinHandle<()>,
+}
+
+impl IntegrationTestSetup {
+    pub async fn new() -> Self {
+        let handle = Handle::current();
+        let task_executor = TokioExecutor::new(handle);
+
+        // TODO(Tsabary): wrap creation of channels in dedicated functions, take channel capacity
+        // from config.
+        const MEMPOOL_INVOCATIONS_QUEUE_SIZE: usize = 32;
+        let (tx_mempool, rx_mempool) =
+            channel::<MempoolRequestAndResponseSender>(MEMPOOL_INVOCATIONS_QUEUE_SIZE);
+        // Build and run gateway; initialize a gateway client.
+        let gateway_mempool_client = MempoolClientImpl::new(tx_mempool.clone());
+        let gateway = create_gateway(Arc::new(gateway_mempool_client)).await;
+        let GatewayNetworkConfig { ip, port } = gateway.config.network_config;
+        let gateway_client = GatewayClient::new(SocketAddr::from((ip, port)));
+        let gateway_handle = task_executor.spawn_with_handle(async move {
+            gateway.run().await.unwrap();
+        });
+
+        // Wait for server to spin up.
+        // TODO(Gilad): Replace with a persistant Client with a built-in retry mechanism,
+        // to avoid the sleep and to protect against CI flakiness.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Build Batcher.
+        // TODO(MockBatcher)
+        let batcher_mempool_client = MempoolClientImpl::new(tx_mempool.clone());
+
+        // Build and run mempool.
+        let mut mempool_server = create_mempool_server(Mempool::empty(), rx_mempool);
+        let mempool_handle = task_executor.spawn_with_handle(async move {
+            mempool_server.start().await;
+        });
+
+        Self {
+            task_executor,
+            gateway_client,
+            batcher_mempool_client,
+            gateway_handle,
+            mempool_handle,
+        }
+    }
+
+    pub async fn assert_add_tx_success(&self, tx: &ExternalTransaction) -> TransactionHash {
+        self.gateway_client.assert_add_tx_success(tx).await
+    }
+
+    pub async fn assert_add_tx_error(&self, tx: &ExternalTransaction) -> GatewayError {
+        self.gateway_client.assert_add_tx_error(tx).await
+    }
+
+    pub async fn get_txs(&mut self, n_txs: usize) -> Vec<ThinTransaction> {
+        let batcher_mempool_client = self.batcher_mempool_client.clone();
+        self.task_executor
+            .spawn(async move { batcher_mempool_client.get_txs(n_txs).await.unwrap() })
+            .await
+            .unwrap()
+    }
+}

--- a/crates/tests-integration/src/integration_test_utils.rs
+++ b/crates/tests-integration/src/integration_test_utils.rs
@@ -1,11 +1,42 @@
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use axum::body::Body;
 use reqwest::{Client, Response};
 use starknet_api::external_transaction::ExternalTransaction;
 use starknet_api::transaction::TransactionHash;
+use starknet_gateway::config::{
+    GatewayConfig, GatewayNetworkConfig, StatefulTransactionValidatorConfig,
+    StatelessTransactionValidatorConfig,
+};
 use starknet_gateway::errors::GatewayError;
+use starknet_gateway::gateway::Gateway;
 use starknet_gateway::starknet_api_test_utils::external_tx_to_json;
+use starknet_gateway::state_reader_test_utils::rpc_test_state_reader_factory;
+use starknet_mempool_types::communication::SharedMempoolClient;
+
+pub async fn create_gateway(mempool_client: SharedMempoolClient) -> Gateway {
+    let stateless_tx_validator_config = StatelessTransactionValidatorConfig {
+        validate_non_zero_l1_gas_fee: true,
+        max_calldata_length: 10,
+        max_signature_length: 2,
+        ..Default::default()
+    };
+
+    let socket: SocketAddr = "127.0.0.1:3000".parse().unwrap();
+    let network_config = GatewayNetworkConfig { ip: socket.ip(), port: socket.port() };
+    let stateful_tx_validator_config = StatefulTransactionValidatorConfig::create_for_testing();
+
+    let gateway_config = GatewayConfig {
+        network_config,
+        stateless_tx_validator_config,
+        stateful_tx_validator_config,
+    };
+
+    let state_reader_factory = Arc::new(rpc_test_state_reader_factory().await);
+
+    Gateway::new(gateway_config, state_reader_factory, mempool_client)
+}
 
 /// A test utility client for interacting with a gateway server.
 pub struct GatewayClient {
@@ -27,7 +58,7 @@ impl GatewayClient {
     }
 
     // TODO: implement when usage eventually arises.
-    pub fn assert_add_tx_error(&self, _tx: &ExternalTransaction) -> GatewayError {
+    pub async fn assert_add_tx_error(&self, _tx: &ExternalTransaction) -> GatewayError {
         todo!()
     }
 

--- a/crates/tests-integration/src/lib.rs
+++ b/crates/tests-integration/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod integration_test_setup;
 pub mod integration_test_utils;

--- a/crates/tests-integration/tests/end_to_end_test.rs
+++ b/crates/tests-integration/tests/end_to_end_test.rs
@@ -1,85 +1,14 @@
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::sync::Arc;
-use std::time::Duration;
-
-use rstest::rstest;
-use starknet_api::transaction::Tip;
-use starknet_gateway::config::{
-    GatewayConfig, GatewayNetworkConfig, StatefulTransactionValidatorConfig,
-    StatelessTransactionValidatorConfig,
-};
-use starknet_gateway::gateway::Gateway;
+use pretty_assertions::assert_eq;
 use starknet_gateway::starknet_api_test_utils::invoke_tx;
-use starknet_gateway::state_reader_test_utils::rpc_test_state_reader_factory;
-use starknet_mempool::communication::create_mempool_server;
-use starknet_mempool::mempool::Mempool;
-use starknet_mempool_integration_tests::integration_test_utils::GatewayClient;
-use starknet_mempool_types::communication::{
-    MempoolClient, MempoolClientImpl, MempoolRequestAndResponseSender, SharedMempoolClient,
-};
-use tokio::sync::mpsc::channel;
-use tokio::task;
-use tokio::time::sleep;
+use starknet_mempool_integration_tests::integration_test_setup::IntegrationTestSetup;
 
-const MEMPOOL_INVOCATIONS_QUEUE_SIZE: usize = 32;
-
-async fn set_up_gateway(mempool_client: SharedMempoolClient) -> SocketAddr {
-    let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let port = 3000;
-    let network_config = GatewayNetworkConfig { ip, port };
-    let stateless_tx_validator_config = StatelessTransactionValidatorConfig {
-        validate_non_zero_l1_gas_fee: true,
-        max_calldata_length: 10,
-        max_signature_length: 2,
-        ..Default::default()
-    };
-    let stateful_tx_validator_config = StatefulTransactionValidatorConfig::create_for_testing();
-    let config = GatewayConfig {
-        network_config,
-        stateless_tx_validator_config,
-        stateful_tx_validator_config,
-    };
-
-    let state_reader_factory = Arc::new(rpc_test_state_reader_factory().await);
-
-    let gateway = Gateway::new(config, state_reader_factory, mempool_client);
-
-    // Setup server
-    tokio::spawn(async move { gateway.run().await });
-
-    // TODO: Avoid using sleep, it slow down the test.
-    // Ensure the server has time to start up
-    sleep(Duration::from_millis(1000)).await;
-    SocketAddr::from((ip, port))
-}
-
-#[rstest]
 #[tokio::test]
 async fn test_end_to_end() {
-    // Initialize Mempool.
-    // TODO(Tsabary): wrap creation of channels in dedicated functions, take channel capacity from
-    // config.
-    let (tx_mempool, rx_mempool) =
-        channel::<MempoolRequestAndResponseSender>(MEMPOOL_INVOCATIONS_QUEUE_SIZE);
-    let mempool = Mempool::empty();
-    let mut mempool_server = create_mempool_server(mempool, rx_mempool);
+    let mut mock_running_system = IntegrationTestSetup::new().await;
 
-    task::spawn(async move {
-        mempool_server.start().await;
-    });
+    let expected_tx_hash = mock_running_system.assert_add_tx_success(&invoke_tx()).await;
 
-    // Initialize Gateway.
-    let gateway_mempool_client = Arc::new(MempoolClientImpl::new(tx_mempool.clone()));
-    let socket_addr = set_up_gateway(gateway_mempool_client).await;
-
-    // Send a transaction.
-    let external_tx = invoke_tx();
-    let gateway_client = GatewayClient::new(socket_addr);
-    gateway_client.assert_add_tx_success(&external_tx).await;
-
-    let batcher_mempool_client = MempoolClientImpl::new(tx_mempool.clone());
-    let mempool_message = batcher_mempool_client.get_txs(2).await.unwrap();
-
-    assert_eq!(mempool_message.len(), 1);
-    assert_eq!(mempool_message[0].tip, Tip(0));
+    let mempool_txs = mock_running_system.get_txs(2).await;
+    assert_eq!(mempool_txs.len(), 1);
+    assert_eq!(mempool_txs[0].tx_hash, expected_tx_hash);
 }


### PR DESCRIPTION
Most of the changes are extraction from the end-to-end test, with the
following differences:
- spawning tasks via `TokioExecutor#spawn_with_handle`, which the mock
  stores as a field to facilitate aborting the job (our `main` will
  likely do something similar to this).
- added abstract add/get tx methods, the add uses the GatewayClient
  util, and the get currently just a channel (and will use the future
  BatcherMock when ready).
- needed to make `config` in `Gateway` public, it doesn't have any
  invariants on it anyway so it should have no problem being pub i think.

commit-id:b41211a9