### PR TITLE
refactor: gateway-client

### DIFF
--- a/crates/gateway/src/errors.rs
+++ b/crates/gateway/src/errors.rs
@@ -19,12 +19,6 @@ pub enum GatewayError {
     StatefulTransactionValidatorError(#[from] StatefulTransactionValidatorError),
     #[error(transparent)]
     StatelessTransactionValidatorError(#[from] StatelessTransactionValidatorError),
-    #[error(transparent)]
-    AxumError(#[from] axum::http::Error),
-    #[error(transparent)]
-    HyperError(#[from] hyper::Error),
-    #[error(transparent)]
-    FromUtf8Error(#[from] std::string::FromUtf8Error),
 }
 
 impl IntoResponse for GatewayError {

--- a/crates/gateway/src/gateway_client.rs
+++ b/crates/gateway/src/gateway_client.rs
@@ -1,9 +1,8 @@
 use std::net::SocketAddr;
 
-use axum::body::{Body, HttpBody};
-use axum::http::{Request, StatusCode};
-use hyper::client::HttpConnector;
-use hyper::{Client, Response};
+use axum::body::Body;
+use hyper::StatusCode;
+use reqwest::{Client, Response};
 use starknet_api::external_transaction::ExternalTransaction;
 
 use crate::errors::GatewayError;
@@ -14,28 +13,44 @@ pub type GatewayResult<T> = Result<T, GatewayError>;
 /// A test utility client for interacting with a gateway server.
 pub struct GatewayClient {
     socket: SocketAddr,
-    client: Client<HttpConnector>,
+    client: Client,
 }
+
 impl GatewayClient {
     pub fn new(socket: SocketAddr) -> Self {
         let client = Client::new();
         Self { socket, client }
     }
 
-    pub async fn add_tx(&self, tx: &ExternalTransaction) -> GatewayResult<String> {
+    // TODO: change from &str to proper return type once that's ready.
+    pub async fn assert_add_tx_success(&self, tx: &ExternalTransaction, expected: &str) {
+        let response =
+            self.add_tx_with_status_check(tx, StatusCode::OK).await.bytes().await.unwrap();
+
+        assert_eq!(response, expected)
+    }
+
+    pub async fn add_tx_with_status_check(
+        &self,
+        tx: &ExternalTransaction,
+        expected_status_code: StatusCode,
+    ) -> Response {
+        let response = self.add_tx(tx).await;
+        assert_eq!(response.status(), expected_status_code);
+
+        response
+    }
+
+    // Prefer using assert_add_tx_success or other higher level methods of this client, to ensure
+    // tests are boilerplate and implementation-detail free.
+    pub async fn add_tx(&self, tx: &ExternalTransaction) -> Response {
         let tx_json = external_invoke_tx_to_json(tx);
-        let request = Request::builder()
-            .method("POST")
-            .uri(format!("http://{}", self.socket) + "/add_tx")
+        self.client
+            .post(format!("http://{}/add_tx", self.socket))
             .header("content-type", "application/json")
-            .body(Body::from(tx_json))?;
-
-        // Send a POST request with the transaction data as the body
-        let response: Response<Body> = self.client.request(request).await?;
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let response_string =
-            String::from_utf8(response.into_body().collect().await?.to_bytes().to_vec())?;
-        Ok(response_string)
+            .body(Body::from(tx_json))
+            .send()
+            .await
+            .unwrap()
     }
 }

--- a/crates/gateway/src/gateway_client.rs
+++ b/crates/gateway/src/gateway_client.rs
@@ -22,7 +22,7 @@ impl GatewayClient {
         Self { socket, client }
     }
 
-    pub async fn add_tx(&self, tx: ExternalTransaction) -> GatewayResult<String> {
+    pub async fn add_tx(&self, tx: &ExternalTransaction) -> GatewayResult<String> {
         let tx_json = external_invoke_tx_to_json(tx);
         let request = Request::builder()
             .method("POST")

--- a/crates/gateway/src/gateway_test.rs
+++ b/crates/gateway/src/gateway_test.rs
@@ -36,7 +36,7 @@ async fn test_add_tx(
     let network_component =
         Arc::new(GatewayNetworkComponent::new(tx_gateway_to_mempool, rx_mempool_to_gateway));
 
-    let json_string = external_invoke_tx_to_json(external_invoke_tx);
+    let json_string = external_invoke_tx_to_json(&external_invoke_tx);
     let tx: ExternalTransaction = serde_json::from_str(&json_string).unwrap();
 
     let mut app_state = AppState {

--- a/crates/gateway/src/starknet_api_test_utils.rs
+++ b/crates/gateway/src/starknet_api_test_utils.rs
@@ -248,9 +248,9 @@ pub fn external_invoke_tx(invoke_args: InvokeTxArgs) -> ExternalTransaction {
     }
 }
 
-pub fn external_invoke_tx_to_json(tx: ExternalTransaction) -> String {
+pub fn external_invoke_tx_to_json(tx: &ExternalTransaction) -> String {
     // Serialize to JSON
-    let mut tx_json = serde_json::to_value(&tx)
+    let mut tx_json = serde_json::to_value(tx)
         .unwrap_or_else(|_| panic!("Failed to serialize transaction: {tx:?}"));
 
     // Add type and version manually

--- a/crates/gateway/tests/end_to_end_test.rs
+++ b/crates/gateway/tests/end_to_end_test.rs
@@ -110,7 +110,7 @@ async fn test_end_to_end() {
     // Send a transaction.
     let external_tx = invoke_tx();
     let gateway_client = gateway_client::GatewayClient::new(SocketAddr::from((ip, port)));
-    let response = gateway_client.add_tx(external_tx).await.unwrap();
+    let response = gateway_client.add_tx(&external_tx).await.unwrap();
     assert_eq!(response, "INVOKE");
 
     // Initialize Mempool.

--- a/crates/gateway/tests/end_to_end_test.rs
+++ b/crates/gateway/tests/end_to_end_test.rs
@@ -110,8 +110,7 @@ async fn test_end_to_end() {
     // Send a transaction.
     let external_tx = invoke_tx();
     let gateway_client = gateway_client::GatewayClient::new(SocketAddr::from((ip, port)));
-    let response = gateway_client.add_tx(&external_tx).await.unwrap();
-    assert_eq!(response, "INVOKE");
+    gateway_client.assert_add_tx_success(&external_tx, "INVOKE").await;
 
     // Initialize Mempool.
     let mut mempool = Mempool::empty(mempool_to_gateway_network, batcher_channels);

--- a/crates/gateway/tests/routing_test.rs
+++ b/crates/gateway/tests/routing_test.rs
@@ -27,7 +27,7 @@ async fn test_routes(
     #[case] external_invoke_tx: ExternalTransaction,
     #[case] expected_response: &str,
 ) {
-    let tx_json = external_invoke_tx_to_json(external_invoke_tx);
+    let tx_json = external_invoke_tx_to_json(&external_invoke_tx);
     let request = Request::post("/add_tx")
         .header("content-type", "application/json")
         .body(Body::from(tx_json))


### PR DESCRIPTION
- Remove errors originating solely from the util: they should not be
  part of the API. In fact, all of this code should not be part of
  production, however this will be dealt with in an upcoming refactor
  that create a dedicated integration tests crate.

- Use reqwest instead of hyper --- it is a more high-level library, so
  less boilerplate.

- Split up `add_tx` into three operations, sending, asserting status
  code, and asserting expected value. The DuplicateTransaction use-case
  will be added soon, and will require asserting for a different
  status-code. The assertion was added to reduce boilerplate in the
  test.

- Note: no need to pass through utf-8, since Bytes<String> supports comparison
with &str.

commit-id:bb48f1f2

---

**Stack**:
- #177 ⬅
- #176


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*