### PR TITLE
chore: switch from udeps to machete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,17 +64,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
 
-  udeps:
+  unused-dependencies:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2024-01-12
-      - uses: Swatinem/rust-cache@v2
-      - name: Install udeps, should be cached unless `Cargo.{toml.lock}` or this workflow change
-        uses: baptiste0928/cargo-install@v3
-        with:
-          crate: cargo-udeps
-      - name: Run udeps (detect unused dependencies)
-        run: cargo udeps
+      - name: Run Machete (detect unused dependencies)
+        uses: bnjbvr/cargo-machete@main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,11 +1978,9 @@ version = "0.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "clap",
  "papyrus_config",
  "pretty_assertions",
  "serde",
- "serde_json",
  "thiserror",
  "tokio",
 ]
@@ -1992,16 +1990,12 @@ name = "mempool_node"
 version = "0.0.0"
 dependencies = [
  "assert_matches",
- "async-trait",
  "clap",
  "const_format",
  "papyrus_config",
  "pretty_assertions",
  "serde",
- "serde_json",
- "starknet_api",
  "starknet_gateway",
- "thiserror",
  "tokio",
  "validator",
 ]
@@ -3200,7 +3194,6 @@ dependencies = [
  "axum",
  "blockifier",
  "cairo-lang-starknet-classes",
- "clap",
  "hyper",
  "mempool_infra",
  "papyrus_config",
@@ -3215,7 +3208,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower",
- "url",
  "validator",
 ]
 

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -15,7 +15,6 @@ testing = []
 axum.workspace = true
 blockifier.workspace = true
 cairo-lang-starknet-classes.workspace = true
-clap.workspace = true
 hyper.workspace = true
 mempool_infra = { path = "../mempool_infra", version = "0.0" }
 papyrus_config.workspace = true
@@ -27,7 +26,6 @@ starknet_mempool_types = { path = "../mempool_types", version = "0.0" }
 thiserror.workspace = true
 tokio.workspace = true
 tower.workspace = true
-url.workspace = true
 validator.workspace = true
 
 [dev-dependencies]

--- a/crates/mempool_infra/Cargo.toml
+++ b/crates/mempool_infra/Cargo.toml
@@ -13,9 +13,7 @@ workspace = true
 
 [dependencies]
 async-trait.workspace = true
-clap.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 papyrus_config.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
@@ -23,4 +21,3 @@ tokio.workspace = true
 [dev-dependencies]
 assert_matches.workspace = true
 pretty_assertions.workspace = true
-

--- a/crates/mempool_node/Cargo.toml
+++ b/crates/mempool_node/Cargo.toml
@@ -9,14 +9,10 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-async-trait.workspace = true
 clap.workspace = true
 const_format.workspace = true
 starknet_gateway = { path = "../gateway", version = "0.0" }
 serde.workspace = true
-serde_json.workspace = true
-starknet_api.workspace = true
-thiserror.workspace = true
 papyrus_config.workspace = true
 tokio.workspace = true
 validator.workspace = true


### PR DESCRIPTION
Seems like machete much faster and catches more stuff (see examples below).

Note: machete uses a regex basically, so there might be false-positives down the line, if this happens add:

```
[package.metadata.cargo-machete]
ignored = ["package_that_machete_thinks_isnt_being_used"]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/178)
<!-- Reviewable:end -->
