### PR TITLE
chore: return TransactionHash from GW add_tx

### DIFF
--- a/crates/gateway/src/gateway_client.rs
+++ b/crates/gateway/src/gateway_client.rs
@@ -4,6 +4,7 @@ use axum::body::Body;
 use hyper::StatusCode;
 use reqwest::{Client, Response};
 use starknet_api::external_transaction::ExternalTransaction;
+use starknet_api::transaction::TransactionHash;
 
 use crate::errors::GatewayError;
 use crate::starknet_api_test_utils::external_tx_to_json;
@@ -22,12 +23,8 @@ impl GatewayClient {
         Self { socket, client }
     }
 
-    // TODO: change from &str to proper return type once that's ready.
-    pub async fn assert_add_tx_success(&self, tx: &ExternalTransaction, expected: &str) {
-        let response =
-            self.add_tx_with_status_check(tx, StatusCode::OK).await.bytes().await.unwrap();
-
-        assert_eq!(response, expected)
+    pub async fn assert_add_tx_success(&self, tx: &ExternalTransaction) -> TransactionHash {
+        self.add_tx_with_status_check(tx, StatusCode::OK).await.json().await.unwrap()
     }
 
     pub async fn add_tx_with_status_check(

--- a/crates/gateway/src/gateway_test.rs
+++ b/crates/gateway/src/gateway_test.rs
@@ -1,9 +1,13 @@
 use std::sync::Arc;
 
+use assert_matches::assert_matches;
 use axum::body::{Bytes, HttpBody};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use blockifier::context::ChainInfo;
+use starknet_api::external_transaction::ExternalTransaction;
+use starknet_api::transaction::TransactionHash;
 use starknet_mempool_types::mempool_types::{
     GatewayNetworkComponent, GatewayToMempoolMessage, MempoolToGatewayMessage,
 };
@@ -15,6 +19,7 @@ use crate::starknet_api_test_utils::invoke_tx;
 use crate::state_reader_test_utils::test_state_reader_factory;
 use crate::stateful_transaction_validator::StatefulTransactionValidator;
 use crate::stateless_transaction_validator::StatelessTransactionValidator;
+use crate::utils::{external_tx_to_account_tx, get_tx_hash};
 
 pub fn app_state(network_component: GatewayNetworkComponent) -> AppState {
     AppState {
@@ -47,15 +52,30 @@ async fn test_add_tx() {
 
     let app_state = app_state(gateway_component);
 
-    let response = add_tx(State(app_state), invoke_tx().into()).await.into_response();
+    let tx = invoke_tx();
+    let tx_hash = calculate_hash(&tx);
+    let response = add_tx(State(app_state), tx.into()).await.into_response();
 
     let status_code = response.status();
     assert_eq!(status_code, StatusCode::OK);
 
     let response_bytes = &to_bytes(response).await;
-    assert!(String::from_utf8_lossy(response_bytes).starts_with("INVOKE"));
+    assert_eq!(tx_hash, serde_json::from_slice(response_bytes).unwrap());
 }
 
 async fn to_bytes(res: Response) -> Bytes {
     res.into_body().collect().await.unwrap().to_bytes()
+}
+
+fn calculate_hash(external_tx: &ExternalTransaction) -> TransactionHash {
+    assert_matches!(
+        external_tx,
+        ExternalTransaction::Invoke(_),
+        "Only Invoke supported for now, extend as needed."
+    );
+
+    let account_tx =
+        external_tx_to_account_tx(external_tx, None, &ChainInfo::create_for_testing().chain_id)
+            .unwrap();
+    get_tx_hash(&account_tx)
 }

--- a/crates/gateway/tests/end_to_end_test.rs
+++ b/crates/gateway/tests/end_to_end_test.rs
@@ -111,7 +111,7 @@ async fn test_end_to_end() {
     // Send a transaction.
     let external_tx = invoke_tx();
     let gateway_client = gateway_client::GatewayClient::new(socket_addr);
-    gateway_client.assert_add_tx_success(&external_tx, "INVOKE").await;
+    gateway_client.assert_add_tx_success(&external_tx).await;
 
     // Initialize Mempool.
     let mut mempool = Mempool::empty(mempool_to_gateway_network, batcher_channels);


### PR DESCRIPTION
- Added a test for the tx_hash inside test_add_tx in the gateway_test, by computing it separately.
- Remove `expected` check in e2e test[_utils], checking the tx_hash is covered now by the gateway_test, also the e2e test will have different expected value to check very soon --- it'll compare external_txs with the thin/internal txs output from the mempool.
- Note: `assert_add_tx_success` might be no longer necessary, will refactor separately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/194)
<!-- Reviewable:end -->
