### PR TITLE
refactor: mempool test setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3254,6 +3254,7 @@ dependencies = [
  "assert_matches",
  "derive_more",
  "mempool_infra",
+ "pretty_assertions",
  "rstest",
  "starknet_api",
  "starknet_mempool_types",

--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -19,6 +19,7 @@ tokio.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+pretty_assertions.workspace = true
 rstest.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }
 tokio.workspace = true


### PR DESCRIPTION
- move: `create_for_testing` to the bottom, no logic changes.
- feat: add a simple macro for generating mempool input.
- feat: add util for testing mempool txs, in ascending order, without having to call get_txs (for use in non-`get_tx` unit tests).
- chore: make existing tests use the above utils, no logic changes.
- chore: add a stability check to the dup-check test; make sure the mempool retains the original tx when the dup is attempted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/199)
<!-- Reviewable:end -->
