### PR TITLE
fix: make check_mempool_txs_eq work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2842,6 +2842,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5310,6 +5319,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "derive_more",
+ "itertools 0.13.0",
  "pretty_assertions",
  "rstest",
  "starknet_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 members = [
     "crates/gateway",
     "crates/mempool",
-    "crates/mempool_types",
-    "crates/mempool_node",
     "crates/mempool_infra",
+    "crates/mempool_node",
+    "crates/mempool_types",
     "crates/starknet_sierra_compile",
     "crates/task_executor",
     "crates/test_utils",
@@ -19,11 +19,11 @@ repository = "https://github.com/starkware-libs/mempool/"
 license = "Apache-2.0"
 
 [workspace.lints.rust]
-warnings = "deny"
 future-incompatible = "deny"
 nonstandard-style = "deny"
 rust-2018-idioms = "deny"
 unused = "deny"
+warnings = "deny"
 
 [workspace.lints.clippy]
 as_conversions = "deny"
@@ -46,9 +46,10 @@ clap = "4.3.10"
 colored = "2.1.0"
 const_format = "0.2.30"
 derive_more = "0.99"
-hyper = { version = "0.14", features = ["client", "http1"] }
 futures = "0.3.30"
+hyper = { version = "0.14", features = ["client", "http1"] }
 indexmap = "2.1.0"
+itertools = "0.13.0"
 # TODO(YaelD, 28/5/2024): The special Papyrus version is needed in order to be aligned with the
 # starknet-api version. This should be removed once we have a mono-repo.
 papyrus_common = { git = "https://github.com/starkware-libs/papyrus.git", rev = "5d37fc32" }

--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -18,6 +18,7 @@ tokio.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+itertools.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
 starknet_api = { workspace = true, features = ["testing"] }

--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -19,6 +19,7 @@ use crate::priority_queue::TransactionPriorityQueue;
 #[path = "mempool_test.rs"]
 pub mod mempool_test;
 
+#[derive(Debug)]
 pub struct Mempool {
     // TODO: add docstring explaining visibility and coupling of the fields.
     txs_queue: TransactionPriorityQueue,


### PR DESCRIPTION
bugs:
- missing assertion...
- use `zip_eq`, which panics if lengths have different length.

refactor:
- add track_caller, to make failures point to the test error location, rather than the test_util itself.
- alphabetize.
- variable naming.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/205)
<!-- Reviewable:end -->
