### PR TITLE
chore: move ClientError definition to component client module

### DIFF
--- a/crates/mempool_infra/src/component_client.rs
+++ b/crates/mempool_infra/src/component_client.rs
@@ -1,3 +1,4 @@
+use thiserror::Error;
 use tokio::sync::mpsc::{channel, Sender};
 
 use crate::component_definitions::ComponentRequestAndResponseSender;
@@ -29,4 +30,10 @@ where
 
         res_rx.recv().await.expect("Inbound connection should be open.")
     }
+}
+
+#[derive(Debug, Error)]
+pub enum ClientError {
+    #[error("Got an unexpected response type.")]
+    UnexpectedResponse,
 }

--- a/crates/mempool_types/src/mempool_types.rs
+++ b/crates/mempool_types/src/mempool_types.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::transaction::{Tip, TransactionHash};
-use starknet_mempool_infra::component_client::ComponentClient;
+use starknet_mempool_infra::component_client::{ClientError, ComponentClient};
 use starknet_mempool_infra::component_definitions::ComponentRequestAndResponseSender;
 use thiserror::Error;
 
@@ -46,11 +46,6 @@ pub enum MempoolClientError {
 pub type MempoolClientResult<T> = Result<T, MempoolClientError>;
 
 // TODO(Tsabary, 1/6/2024): Move communication-related definitions to a separate file.
-#[derive(Debug, Error)]
-pub enum ClientError {
-    #[error("Got an unexpected response type.")]
-    UnexpectedResponse,
-}
 
 /// Serves as the mempool's shared interface. Requires `Send + Sync` to allow transferring and
 /// sharing resources (inputs, futures) across threads.


### PR DESCRIPTION
**Stack**:
- #224
- #223 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/223)
<!-- Reviewable:end -->
