### PR TITLE
feat: initialize accounts in integration tests

### DIFF
--- a/crates/tests-integration/src/integration_test_setup.rs
+++ b/crates/tests-integration/src/integration_test_setup.rs
@@ -30,7 +30,7 @@ pub struct IntegrationTestSetup {
 }
 
 impl IntegrationTestSetup {
-    pub async fn new() -> Self {
+    pub async fn new(n_initialized_account_contracts: u16) -> Self {
         let handle = Handle::current();
         let task_executor = TokioExecutor::new(handle);
 
@@ -41,7 +41,8 @@ impl IntegrationTestSetup {
             channel::<MempoolRequestAndResponseSender>(MEMPOOL_INVOCATIONS_QUEUE_SIZE);
         // Build and run gateway; initialize a gateway client.
         let gateway_mempool_client = MempoolClientImpl::new(tx_mempool.clone());
-        let gateway = create_gateway(Arc::new(gateway_mempool_client)).await;
+        let gateway =
+            create_gateway(Arc::new(gateway_mempool_client), n_initialized_account_contracts).await;
         let GatewayNetworkConfig { ip, port } = gateway.config.network_config;
         let gateway_client = GatewayClient::new(SocketAddr::from((ip, port)));
         let gateway_handle = task_executor.spawn_with_handle(async move {

--- a/crates/tests-integration/src/integration_test_utils.rs
+++ b/crates/tests-integration/src/integration_test_utils.rs
@@ -16,7 +16,10 @@ use starknet_mempool_types::communication::SharedMempoolClient;
 
 use crate::state_reader::rpc_test_state_reader_factory;
 
-pub async fn create_gateway(mempool_client: SharedMempoolClient) -> Gateway {
+pub async fn create_gateway(
+    mempool_client: SharedMempoolClient,
+    n_initialized_account_contracts: u16,
+) -> Gateway {
     let stateless_tx_validator_config = StatelessTransactionValidatorConfig {
         validate_non_zero_l1_gas_fee: true,
         max_calldata_length: 10,
@@ -34,7 +37,8 @@ pub async fn create_gateway(mempool_client: SharedMempoolClient) -> Gateway {
         stateful_tx_validator_config,
     };
 
-    let state_reader_factory = Arc::new(rpc_test_state_reader_factory().await);
+    let state_reader_factory =
+        Arc::new(rpc_test_state_reader_factory(n_initialized_account_contracts).await);
 
     Gateway::new(gateway_config, state_reader_factory, mempool_client)
 }

--- a/crates/tests-integration/src/state_reader.rs
+++ b/crates/tests-integration/src/state_reader.rs
@@ -40,9 +40,11 @@ type ContractClassesMap =
 
 /// StateReader for integration tests.
 ///
-/// Create a papyrus storage reader and Spawns a papyrus rpc server for it.
-
-pub async fn rpc_test_state_reader_factory() -> RpcStateReaderFactory {
+/// Creates a papyrus storage reader and Spawns a papyrus rpc server for it.
+/// A variable number of identical accounts and test contracts are initialized and funded.
+pub async fn rpc_test_state_reader_factory(
+    n_initialized_account_contracts: u16,
+) -> RpcStateReaderFactory {
     const RPC_SPEC_VERION: &str = "V0_7";
     const JSON_RPC_VERSION: &str = "2.0";
     let cairo_version = CairoVersion::Cairo1;
@@ -53,7 +55,7 @@ pub async fn rpc_test_state_reader_factory() -> RpcStateReaderFactory {
     let storage_reader = initialize_papyrus_test_state(
         block_context.chain_info(),
         BALANCE,
-        &[(account_contract, 1), (test_contract, 1)],
+        &[(account_contract, n_initialized_account_contracts), (test_contract, 1)],
     );
     let addr = run_papyrus_rpc_server(storage_reader).await;
 

--- a/crates/tests-integration/tests/end_to_end_test.rs
+++ b/crates/tests-integration/tests/end_to_end_test.rs
@@ -4,7 +4,7 @@ use starknet_mempool_integration_tests::integration_test_setup::IntegrationTestS
 
 #[tokio::test]
 async fn test_end_to_end() {
-    let mut mock_running_system = IntegrationTestSetup::new().await;
+    let mut mock_running_system = IntegrationTestSetup::new(1).await;
 
     let expected_tx_hash =
         mock_running_system.assert_add_tx_success(&invoke_tx(CairoVersion::Cairo1)).await;


### PR DESCRIPTION
Currently rpc state reader defaults to a single account contract, this
extends the behavior to create a variable number, to make it easier to
setup integration tests (otherwise every test will have a bunch of
deploy_account expensive boilerplate).

Alternative: increase the default to something sensible, like 6.
This will most likely suffice, but it's a bit of a magic number and
might have unnecessary overhead. That is, while debugging users might
not understand where so many contracts are coming from.

commit-id:4ef4de46

---

**Stack**:
- #253
- #252
- #268 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/268)
<!-- Reviewable:end -->
