### PR TITLE
fix: change ComponentRunner start param to '&mut self'

### DIFF
--- a/crates/mempool_infra/src/component_runner.rs
+++ b/crates/mempool_infra/src/component_runner.rs
@@ -22,5 +22,5 @@ pub trait ComponentCreator<T: SerializeConfig> {
 #[async_trait]
 pub trait ComponentRunner {
     /// Start the component. Normally this function should never return.
-    async fn start(&self) -> Result<(), ComponentStartError>;
+    async fn start(&mut self) -> Result<(), ComponentStartError>;
 }

--- a/crates/mempool_infra/src/component_runner_test.rs
+++ b/crates/mempool_infra/src/component_runner_test.rs
@@ -48,7 +48,7 @@ mod test_component_a {
 
     #[async_trait]
     impl ComponentRunner for TestComponentA {
-        async fn start(&self) -> Result<(), ComponentStartError> {
+        async fn start(&mut self) -> Result<(), ComponentStartError> {
             println!("TestComponent1::start(), component: {:#?}", self);
             self.local_start().await.map_err(|_err| ComponentStartError::InternalComponentError)
         }
@@ -87,7 +87,7 @@ mod test_component_b {
 
     #[async_trait]
     impl ComponentRunner for TestComponentB {
-        async fn start(&self) -> Result<(), ComponentStartError> {
+        async fn start(&mut self) -> Result<(), ComponentStartError> {
             println!("TestComponent2::start(): component: {:#?}", self);
             match self.config.u32_field {
                 43 => Err(ComponentStartError::InternalComponentError),
@@ -103,7 +103,7 @@ use test_component_a::{TestComponentA, TestConfigA};
 #[tokio::test]
 async fn test_component_a() {
     let test_config = TestConfigA { bool_field: true };
-    let component = TestComponentA::create(test_config);
+    let mut component = TestComponentA::create(test_config);
     assert_matches!(component.start().await, Ok(()));
 }
 
@@ -112,17 +112,17 @@ use test_component_b::{TestComponentB, TestConfigB};
 #[tokio::test]
 async fn test_component_b() {
     let test_config = TestConfigB { u32_field: 42 };
-    let component = TestComponentB::create(test_config);
+    let mut component = TestComponentB::create(test_config);
     assert_matches!(component.start().await, Ok(()));
 
     let test_config = TestConfigB { u32_field: 43 };
-    let component = TestComponentB::create(test_config);
+    let mut component = TestComponentB::create(test_config);
     assert_matches!(component.start().await, Err(e) => {
         assert_eq!(e, ComponentStartError::InternalComponentError);
     });
 
     let test_config = TestConfigB { u32_field: 44 };
-    let component = TestComponentB::create(test_config);
+    let mut component = TestComponentB::create(test_config);
     assert_matches!(component.start().await, Err(e) => {
         assert_eq!(e, ComponentStartError::ComponentConfigError);
     });


### PR DESCRIPTION
**Stack**:
- #292
- #291
- #290
- #289 ⬅
- #265
- #262
- #261


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/289)
<!-- Reviewable:end -->
