### PR TITLE
fix: switch insertion order in add_tx

### DIFF
--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -83,8 +83,8 @@ impl Mempool {
             Vacant(entry) => {
                 entry.insert(account.state);
                 // TODO(Mohammad): use `handle_tx`.
-                self.txs_queue.push(tx.clone().into());
-                self.tx_pool.insert(tx)?;
+                self.tx_pool.insert(tx.clone())?;
+                self.txs_queue.push(tx.into());
 
                 Ok(())
             }


### PR DESCRIPTION
`state`, as it's currently implemented, will be soon removed. (We'll add a similar construct soon to track current block state, but it'll be behave differently.)

Therefore, we'll need to rely on the tx_pool's dup check; insertion to the queue does not check for dups, it _assumes_ that dup checks have already occured.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/299)
<!-- Reviewable:end -->
