### PR TITLE
fix: make TransactionReference's inner public

### DIFF
--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -110,4 +110,4 @@ impl Mempool {
 /// TODO(Mohammad): rename this struct to `ThinTransaction` once that name
 /// becomes available, to better reflect its purpose and usage.
 #[derive(Clone, Debug, Default, derive_more::Deref, derive_more::From)]
-pub struct TransactionReference(ThinTransaction);
+pub struct TransactionReference(pub ThinTransaction);


### PR DESCRIPTION
There are no invariants to protect.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/301)
<!-- Reviewable:end -->
