### PR TITLE
feat: make mempool::new return error

### DIFF
--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -24,7 +24,7 @@ pub struct Mempool {
 }
 
 impl Mempool {
-    pub fn new(inputs: impl IntoIterator<Item = MempoolInput>) -> Self {
+    pub fn new(inputs: impl IntoIterator<Item = MempoolInput>) -> MempoolResult<Self> {
         let mut mempool = Mempool::empty();
 
         for MempoolInput { tx, account: Account { sender_address, state } } in inputs.into_iter() {
@@ -38,18 +38,12 @@ impl Mempool {
                     sender_address, tx
                 );
             }
-            // Attempt to push the transaction into the tx_pool
-            if let Err(err) = mempool.tx_pool.insert(tx.clone()) {
-                panic!(
-                    "Transaction: {:?} already exists in the mempool. Error: {:?}",
-                    tx.tx_hash, err
-                );
-            }
 
+            mempool.tx_pool.insert(tx.clone())?;
             mempool.txs_queue.insert(tx.into());
         }
 
-        mempool
+        Ok(mempool)
     }
 
     pub fn empty() -> Self {

--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -75,7 +75,8 @@ fn test_get_txs(#[case] requested_txs: usize) {
         MempoolInput { tx: tx_tip_50_address_0.clone(), account: account1 },
         MempoolInput { tx: tx_tip_100_address_1.clone(), account: account2 },
         MempoolInput { tx: tx_tip_10_address_2.clone(), account: account3 },
-    ]);
+    ])
+    .unwrap();
 
     let sorted_txs = [tx_tip_100_address_1, tx_tip_50_address_0, tx_tip_10_address_2];
 


### PR DESCRIPTION
Duplicates inside the inputs is an input error for the mempool, so should be returned to the user.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/303)
<!-- Reviewable:end -->
