### PR TITLE
chore: move AddressPriorityQueue to pool

### DIFF
--- a/crates/mempool/src/transaction_pool.rs
+++ b/crates/mempool/src/transaction_pool.rs
@@ -1,4 +1,4 @@
-use std::collections::{btree_map, hash_map, BTreeMap, HashMap};
+use std::collections::{btree_map, hash_map, BTreeMap, HashMap, VecDeque};
 
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::transaction::TransactionHash;
@@ -70,5 +70,45 @@ impl TransactionPool {
 
     pub fn get(&self, tx_hash: TransactionHash) -> MempoolResult<&ThinTransaction> {
         self.tx_pool.get(&tx_hash).ok_or(MempoolError::TransactionNotFound { tx_hash })
+    }
+}
+
+// TODO: Use in txs_by_account.
+// TODO: remove when is used.
+#[allow(dead_code)]
+// Invariant: Transactions have strictly increasing nonces, without gaps.
+// Assumption: Transactions are provided in the correct order.
+#[derive(Default)]
+pub struct AddressPriorityQueue(VecDeque<ThinTransaction>);
+
+// TODO: remove when is used.
+#[allow(dead_code)]
+impl AddressPriorityQueue {
+    pub fn push(&mut self, tx: ThinTransaction) {
+        if let Some(last_tx) = self.0.back() {
+            assert_eq!(
+                tx.nonce,
+                last_tx.nonce.try_increment().expect("Nonce overflow."),
+                "Nonces must be strictly increasing without gaps."
+            );
+        }
+
+        self.0.push_back(tx);
+    }
+
+    pub fn top(&self) -> Option<&ThinTransaction> {
+        self.0.front()
+    }
+
+    pub fn pop_front(&mut self) -> Option<ThinTransaction> {
+        self.0.pop_front()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn contains(&self, tx: &ThinTransaction) -> bool {
+        self.0.contains(tx)
     }
 }

--- a/crates/mempool/src/transaction_queue.rs
+++ b/crates/mempool/src/transaction_queue.rs
@@ -1,8 +1,7 @@
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeSet, HashMap};
 
 use starknet_api::core::{ContractAddress, Nonce};
-use starknet_mempool_types::mempool_types::ThinTransaction;
 
 use crate::mempool::TransactionReference;
 // Assumption: for the MVP only one transaction from the same contract class can be in the mempool
@@ -86,44 +85,5 @@ impl Ord for QueuedTransaction {
 impl PartialOrd for QueuedTransaction {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
-    }
-}
-
-// TODO: remove when is used.
-#[allow(dead_code)]
-// Invariant: Transactions have strictly increasing nonces, without gaps.
-// Assumption: Transactions are provided in the correct order.
-#[derive(Default)]
-pub struct AddressPriorityQueue(VecDeque<ThinTransaction>);
-
-// TODO: remove when is used.
-#[allow(dead_code)]
-impl AddressPriorityQueue {
-    pub fn push(&mut self, tx: ThinTransaction) {
-        if let Some(last_tx) = self.0.back() {
-            assert_eq!(
-                tx.nonce,
-                last_tx.nonce.try_increment().expect("Nonce overflow."),
-                "Nonces must be strictly increasing without gaps."
-            );
-        }
-
-        self.0.push_back(tx);
-    }
-
-    pub fn top(&self) -> Option<&ThinTransaction> {
-        self.0.front()
-    }
-
-    pub fn pop_front(&mut self) -> Option<ThinTransaction> {
-        self.0.pop_front()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    pub fn contains(&self, tx: &ThinTransaction) -> bool {
-        self.0.contains(tx)
     }
 }


### PR DESCRIPTION
Subsequent commits will use the switch the inner type of txs_by_account
and use it there, also rename.

commit-id:30696bc0

---

**Stack**:
- #320
- #318
- #317
- #316
- #315
- #314
- #313 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/313)
<!-- Reviewable:end -->
