### PR TITLE
refactor: rename address pq

### DIFF
--- a/crates/mempool/src/transaction_pool.rs
+++ b/crates/mempool/src/transaction_pool.rs
@@ -79,11 +79,11 @@ impl TransactionPool {
 // Invariant: Transactions have strictly increasing nonces, without gaps.
 // Assumption: Transactions are provided in the correct order.
 #[derive(Default)]
-pub struct AddressPriorityQueue(VecDeque<ThinTransaction>);
+pub struct AccountTransactionIndex(VecDeque<ThinTransaction>);
 
 // TODO: remove when is used.
 #[allow(dead_code)]
-impl AddressPriorityQueue {
+impl AccountTransactionIndex {
     pub fn push(&mut self, tx: ThinTransaction) {
         if let Some(last_tx) = self.0.back() {
             assert_eq!(


### PR DESCRIPTION
New name better implies this being a transaction index, rather than an
address index.

commit-id:ecb46826

---

**Stack**:
- #320
- #318
- #317
- #316
- #315
- #314 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*