### PR TITLE
feat: add out-of-order support to account tx index

### DIFF
--- a/crates/mempool/src/transaction_pool.rs
+++ b/crates/mempool/src/transaction_pool.rs
@@ -1,4 +1,4 @@
-use std::collections::{btree_map, hash_map, BTreeMap, HashMap, VecDeque};
+use std::collections::{btree_map, hash_map, BTreeMap, HashMap};
 
 use starknet_api::core::{ContractAddress, Nonce};
 use starknet_api::transaction::TransactionHash;
@@ -76,39 +76,7 @@ impl TransactionPool {
 // TODO: Use in txs_by_account.
 // TODO: remove when is used.
 #[allow(dead_code)]
-// Invariant: Transactions have strictly increasing nonces, without gaps.
-// Assumption: Transactions are provided in the correct order.
 #[derive(Default)]
-pub struct AccountTransactionIndex(VecDeque<ThinTransaction>);
-
-// TODO: remove when is used.
-#[allow(dead_code)]
-impl AccountTransactionIndex {
-    pub fn push(&mut self, tx: ThinTransaction) {
-        if let Some(last_tx) = self.0.back() {
-            assert_eq!(
-                tx.nonce,
-                last_tx.nonce.try_increment().expect("Nonce overflow."),
-                "Nonces must be strictly increasing without gaps."
-            );
-        }
-
-        self.0.push_back(tx);
-    }
-
-    pub fn top(&self) -> Option<&ThinTransaction> {
-        self.0.front()
-    }
-
-    pub fn pop_front(&mut self) -> Option<ThinTransaction> {
-        self.0.pop_front()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    pub fn contains(&self, tx: &ThinTransaction) -> bool {
-        self.0.contains(tx)
-    }
-}
+pub struct AccountTransactionIndex(
+    pub HashMap<ContractAddress, BTreeMap<Nonce, TransactionReference>>,
+);


### PR DESCRIPTION
Since this now supports out of order (and holes in particular), no
invariants on the inner type are necessary, and so no API interface is
strictly necessary.

Subsequent commits will extract logic from inside tx pool into methods
again.

commit-id:06539624

---

**Stack**:
- #320
- #318
- #317
- #316
- #315 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/315)
<!-- Reviewable:end -->
