### PR TITLE
feat: add AccountTransactionIndex insert

### DIFF
--- a/crates/mempool/src/transaction_pool.rs
+++ b/crates/mempool/src/transaction_pool.rs
@@ -80,3 +80,10 @@ impl TransactionPool {
 pub struct AccountTransactionIndex(
     pub HashMap<ContractAddress, BTreeMap<Nonce, TransactionReference>>,
 );
+
+impl AccountTransactionIndex {
+    /// If the transaction already exists in the mapping, the old value is returned.
+    pub fn insert(&mut self, tx: TransactionReference) -> Option<TransactionReference> {
+        self.0.entry(tx.sender_address).or_default().insert(tx.nonce, tx)
+    }
+}


### PR DESCRIPTION
Until we support fee escalation, this should always return None.

Subsequent PRs will use this DS, and panic if `Some` is returned.

commit-id:b0eee880

---

**Stack**:
- #320
- #318
- #317
- #316 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*