### PR TITLE
fix: dont clone tx in insert_tx

### DIFF
--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -79,9 +79,11 @@ impl Mempool {
 
     fn insert_tx(&mut self, input: MempoolInput) -> MempoolResult<()> {
         let tx = input.tx;
+        let tx_reference = TransactionReference::new(&tx);
 
-        self.tx_pool.insert(tx.clone())?;
-        self.tx_queue.insert(TransactionReference::new(&tx));
+        self.tx_pool.insert(tx)?;
+        // FIXME: Check nonce before adding!
+        self.tx_queue.insert(tx_reference);
 
         Ok(())
     }


### PR DESCRIPTION
Subsequent PRs will add the nonce check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/346)
<!-- Reviewable:end -->
