### PR TITLE
refactor: mock batcher as a service

### DIFF
--- a/crates/tests-integration/src/integration_test_setup.rs
+++ b/crates/tests-integration/src/integration_test_setup.rs
@@ -8,7 +8,6 @@ use starknet_mempool_node::communication::{create_node_channels, create_node_cli
 use starknet_mempool_node::components::create_components;
 use starknet_mempool_node::servers::{create_servers, get_server_future};
 use starknet_mempool_types::mempool_types::ThinTransaction;
-use starknet_task_executor::executor::TaskExecutor;
 use starknet_task_executor::tokio_executor::TokioExecutor;
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
@@ -78,7 +77,6 @@ impl IntegrationTestSetup {
     }
 
     pub async fn get_txs(&self, n_txs: usize) -> Vec<ThinTransaction> {
-        let batcher = self.batcher.clone();
-        self.task_executor.spawn(async move { batcher.get_txs(n_txs).await }).await.unwrap()
+        self.batcher.get_txs(n_txs).await
     }
 }

--- a/crates/tests-integration/src/mock_batcher.rs
+++ b/crates/tests-integration/src/mock_batcher.rs
@@ -1,7 +1,6 @@
 use starknet_mempool_types::communication::SharedMempoolClient;
 use starknet_mempool_types::mempool_types::ThinTransaction;
 
-#[derive(Clone)]
 pub struct MockBatcher {
     mempool_client: SharedMempoolClient,
 }


### PR DESCRIPTION
- Refactored `IntegrationTestSetup` to use the batcher as a service.
- Created `BatcherCommand` for messages sent to the batcher, triggering it to start. Currently, it only prints the connection but will later be used to get messages from the mempool.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/349)
<!-- Reviewable:end -->
