### PR TITLE
refactor: reverse order iterator for transaction queue

### DIFF
--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -109,7 +109,7 @@ fn test_add_tx(mut mempool: Mempool) {
     add_tx(&mut mempool, &input_tip_80_address_2);
 
     let expected_txs =
-        &[input_tip_50_address_0.tx, input_tip_80_address_2.tx, input_tip_100_address_1.tx];
+        &[input_tip_100_address_1.tx, input_tip_80_address_2.tx, input_tip_50_address_0.tx];
     check_mempool_txs_eq(&mempool, expected_txs)
 }
 
@@ -152,7 +152,7 @@ fn test_add_tx_with_identical_tip_succeeds(mut mempool: Mempool) {
 
     // TODO: currently hash comparison tie-breaks the two. Once more robust tie-breaks are added
     // replace this assertion with a dedicated test.
-    check_mempool_txs_eq(&mempool, &[input2.tx, input1.tx]);
+    check_mempool_txs_eq(&mempool, &[input1.tx, input2.tx]);
 }
 
 #[rstest]
@@ -165,5 +165,5 @@ fn test_tip_priority_over_tx_hash(mut mempool: Mempool) {
 
     add_tx(&mut mempool, &input_big_tip_small_hash);
     add_tx(&mut mempool, &input_small_tip_big_hash);
-    check_mempool_txs_eq(&mempool, &[input_small_tip_big_hash.tx, input_big_tip_small_hash.tx])
+    check_mempool_txs_eq(&mempool, &[input_big_tip_small_hash.tx, input_small_tip_big_hash.tx])
 }

--- a/crates/mempool/src/transaction_queue.rs
+++ b/crates/mempool/src/transaction_queue.rs
@@ -39,8 +39,10 @@ impl TransactionQueue {
         txs.into_iter().map(|tx| tx.tx_hash).collect()
     }
 
+    /// Returns an iterator of the current eligible transactions for sequencing, ordered by their
+    /// priority.
     pub fn iter(&self) -> impl Iterator<Item = &TransactionReference> {
-        self.queue.iter().map(|tx| &tx.0)
+        self.queue.iter().rev().map(|tx| &tx.0)
     }
 
     pub fn _get_nonce(&self, address: &ContractAddress) -> Option<&Nonce> {


### PR DESCRIPTION
Update TransactionQueue iter to return reverse order iterator.
- Refactored the `iter` function to return an iterator in reverse order, contrasting with the `BTreeSet` iterator which returns in ascending order.
- This change makes the iteration more intuitive for the mempool queue, which returns transactions by reverse tip order.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/364)
<!-- Reviewable:end -->
