### PR TITLE
fix: fix nonce type in mempool_test

### DIFF
--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -31,17 +31,17 @@ macro_rules! add_tx_input {
             tip: Tip($tip),
             tx_hash: TransactionHash(StarkHash::from($tx_hash)),
             sender_address,
-            nonce: Nonce($nonce),
+            nonce: Nonce(felt!($nonce)),
         };
         MempoolInput { tx, account }
     }};
     // Pattern for three arguments.
     (tip: $tip:expr, tx_hash: $tx_hash:expr, sender_address: $sender_address:expr) => {
-        add_tx_input!(tip: $tip, tx_hash: $tx_hash, sender_address: $sender_address, nonce: Felt::ZERO)
+        add_tx_input!(tip: $tip, tx_hash: $tx_hash, sender_address: $sender_address, nonce: 0_u8)
     };
     // Pattern for two arguments.
     (tip: $tip:expr, tx_hash: $tx_hash:expr) => {
-        add_tx_input!(tip: $tip, tx_hash: $tx_hash, sender_address: "0x0", nonce: Felt::ZERO)
+        add_tx_input!(tip: $tip, tx_hash: $tx_hash, sender_address: "0x0", nonce: 0_u8)
     };
 }
 


### PR DESCRIPTION
`felt!` doesn't support Felt type :unamused:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/375)
<!-- Reviewable:end -->
