### PR TITLE
fix: remove unnecessary cfg and import

### DIFF
--- a/crates/mempool_node/src/config/config_test.rs
+++ b/crates/mempool_node/src/config/config_test.rs
@@ -1,5 +1,4 @@
-#[cfg(any(feature = "testing", test))]
-use std::env::{self};
+use std::env;
 use std::fs::File;
 
 use assert_json_diff::assert_json_eq;


### PR DESCRIPTION
- cfg seemed to be a combo of a logical merge conflict and legacy code. Anyway, the whole test is conditionally compiled so adding cfg(test) is basically a nop.
Also there is no `testing` feature in this crate :P

- Import `self` is only necessary when other imports from the crate are needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/424)
<!-- Reviewable:end -->
