### PR TITLE
fix: remove testing feature from sierra compile

### DIFF
--- a/crates/starknet_sierra_compile/src/lib.rs
+++ b/crates/starknet_sierra_compile/src/lib.rs
@@ -4,5 +4,5 @@ pub mod compile;
 pub mod errors;
 pub mod utils;
 
-#[cfg(any(feature = "testing", test))]
+#[cfg(test)]
 pub mod test_utils;


### PR DESCRIPTION
- there is no `testing` feature in that crate
- adding a `testing` feature requires reconsidering the visibility of the items inside test_utils: currently it has a single `pub(crate)` func, making it unusable by users even with a `testing` feature. There is also a `pub` struct, but that is also only used inside of the above `pub(crate)`, which makes its usability unclear.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/425)
<!-- Reviewable:end -->
