### PR TITLE
feat: add tx_pool checker for mempool test

### DIFF
--- a/crates/mempool/src/mempool.rs
+++ b/crates/mempool/src/mempool.rs
@@ -85,6 +85,11 @@ impl Mempool {
 
         Ok(())
     }
+
+    #[cfg(test)]
+    pub(crate) fn _tx_pool(&self) -> &TransactionPool {
+        &self.tx_pool
+    }
 }
 
 /// Provides a lightweight representation of a transaction for mempool usage (e.g., excluding

--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use itertools::zip_eq;
+use itertools::{enumerate, zip_eq};
 use pretty_assertions::assert_eq;
 use rstest::{fixture, rstest};
 use starknet_api::core::{ContractAddress, Nonce, PatriciaKey};
@@ -81,11 +81,9 @@ fn assert_eq_mempool_queue(mempool: &Mempool, expected_queue: &[ThinTransaction]
     let mempool_txs = mempool.iter();
     let expected_queue = expected_queue.iter().map(TransactionReference::new);
 
-    assert!(
-        zip_eq(expected_queue, mempool_txs)
-            // Deref the inner mempool tx type.
-            .all(|(expected_tx, mempool_tx)| expected_tx == *mempool_tx)
-    );
+    for (i, (expected_tx, mempool_tx)) in enumerate(zip_eq(expected_queue, mempool_txs)) {
+        assert_eq!(expected_tx, *mempool_tx, "Transaction {i} in the queue is not as expected");
+    }
 }
 
 #[rstest]

--- a/crates/mempool/src/mempool_test.rs
+++ b/crates/mempool/src/mempool_test.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use assert_matches::assert_matches;
 use itertools::{enumerate, zip_eq};
 use pretty_assertions::assert_eq;
@@ -72,6 +74,20 @@ macro_rules! add_tx_input {
 #[fixture]
 fn mempool() -> Mempool {
     Mempool::empty()
+}
+
+// TODO(Ayelet): replace with MempoolState checker.
+#[track_caller]
+fn _assert_eq_mempool_state(
+    mempool: &Mempool,
+    expected_pool: &[ThinTransaction],
+    expected_queue: &[ThinTransaction],
+) {
+    assert_eq_mempool_queue(mempool, expected_queue);
+
+    let expected_pool: HashMap<_, _> =
+        expected_pool.iter().cloned().map(|tx| (tx.tx_hash, tx)).collect();
+    assert_eq!(mempool._tx_pool()._tx_pool(), &expected_pool);
 }
 
 // Asserts that the transactions in the mempool are in ascending order as per the expected

--- a/crates/mempool/src/transaction_pool.rs
+++ b/crates/mempool/src/transaction_pool.rs
@@ -7,6 +7,8 @@ use starknet_mempool_types::mempool_types::{MempoolResult, ThinTransaction};
 
 use crate::mempool::TransactionReference;
 
+type HashToTransaction = HashMap<TransactionHash, ThinTransaction>;
+
 /// Contains all transactions currently held in the mempool.
 /// Invariant: both data structures are consistent regarding the existence of transactions:
 /// A transaction appears in one if and only if it appears in the other.
@@ -14,7 +16,7 @@ use crate::mempool::TransactionReference;
 #[derive(Debug, Default)]
 pub struct TransactionPool {
     // Holds the complete transaction objects; it should be the sole entity that does so.
-    tx_pool: HashMap<TransactionHash, ThinTransaction>,
+    tx_pool: HashToTransaction,
     // Transactions organized by account address, sorted by ascending nonce values.
     txs_by_account: AccountTransactionIndex,
 }
@@ -69,6 +71,11 @@ impl TransactionPool {
         nonce: Nonce,
     ) -> Option<&TransactionReference> {
         self.txs_by_account.get(address, nonce)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn _tx_pool(&self) -> &HashToTransaction {
+        &self.tx_pool
     }
 }
 


### PR DESCRIPTION
- Requires adding accessors to the private tx_pools; these should not be
used outside of our own tests.

- Didn't add a standalone tx_pool checker, can't think of a reason to
  test the pool without the queue (but the reverse is sensible
  somewhat).

- New tester will soon be used to test multi-nonce

commit-id:ba871431

---

**Stack**:
- #429
- #428 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/428)
<!-- Reviewable:end -->
