### PR TITLE
feat: add custom accounts to test rpc state reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5452,6 +5452,7 @@ dependencies = [
  "blockifier 0.8.0-rc.0 (git+https://github.com/starkware-libs/blockifier.git?rev=32191d41)",
  "cairo-lang-starknet-classes",
  "indexmap 2.2.6",
+ "itertools 0.13.0",
  "mempool_test_utils",
  "papyrus_common",
  "papyrus_rpc",

--- a/crates/tests-integration/Cargo.toml
+++ b/crates/tests-integration/Cargo.toml
@@ -13,22 +13,23 @@ axum.workspace = true
 blockifier.workspace = true
 cairo-lang-starknet-classes.workspace = true
 indexmap.workspace = true
+itertools.workspace = true
+mempool_test_utils = { path = "../mempool_test_utils", version = "0.0" }
 papyrus_common.workspace = true
 papyrus_rpc.workspace = true
 papyrus_storage.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
+starknet-types-core.workspace = true
 starknet_api.workspace = true
 starknet_client.workspace = true
 starknet_gateway = { path = "../gateway", version = "0.0", features = ["testing"] }
-starknet_mempool_node = { path = "../mempool_node", version = "0.0" }
 starknet_mempool_infra = { path = "../mempool_infra", version = "0.0" }
+starknet_mempool_node = { path = "../mempool_node", version = "0.0" }
 starknet_mempool_types = { path = "../mempool_types", version = "0.0" }
 starknet_task_executor = { path = "../task_executor", version = "0.0" }
-starknet-types-core.workspace = true
 strum.workspace = true
 tempfile.workspace = true
-mempool_test_utils = { path = "../mempool_test_utils", version = "0.0" }
 tokio.workspace = true
 
 [dev-dependencies]

--- a/crates/tests-integration/src/integration_test_setup.rs
+++ b/crates/tests-integration/src/integration_test_setup.rs
@@ -1,5 +1,7 @@
 use std::net::SocketAddr;
 
+use blockifier::test_utils::contracts::FeatureContract;
+use blockifier::test_utils::CairoVersion;
 use starknet_api::rpc_transaction::RPCTransaction;
 use starknet_api::transaction::TransactionHash;
 use starknet_gateway::config::GatewayNetworkConfig;
@@ -27,6 +29,15 @@ pub struct IntegrationTestSetup {
 
 impl IntegrationTestSetup {
     pub async fn new(n_accounts: usize) -> Self {
+        let default_account_contract =
+            FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1);
+        let accounts = std::iter::repeat(default_account_contract).take(n_accounts);
+        Self::new_for_account_contracts(accounts).await
+    }
+
+    pub async fn new_for_account_contracts(
+        accounts: impl IntoIterator<Item = FeatureContract>,
+    ) -> Self {
         let handle = Handle::current();
         let task_executor = TokioExecutor::new(handle);
 
@@ -34,7 +45,7 @@ impl IntegrationTestSetup {
         configure_tracing();
 
         // Spawn a papyrus rpc server for a papyrus storage reader.
-        let rpc_server_addr = spawn_test_rpc_state_reader(n_accounts).await;
+        let rpc_server_addr = spawn_test_rpc_state_reader(accounts).await;
 
         // Derive the configuration for the mempool node.
         let config = create_config(rpc_server_addr).await;

--- a/crates/tests-integration/tests/end_to_end_test.rs
+++ b/crates/tests-integration/tests/end_to_end_test.rs
@@ -1,3 +1,4 @@
+use blockifier::test_utils::contracts::FeatureContract;
 use blockifier::test_utils::CairoVersion;
 use mempool_test_utils::starknet_api_test_utils::{deploy_account_tx, invoke_tx};
 use starknet_api::transaction::TransactionHash;
@@ -5,8 +6,11 @@ use starknet_mempool_integration_tests::integration_test_setup::IntegrationTestS
 
 #[tokio::test]
 async fn test_end_to_end() {
-    let n_accounts = 1;
-    let mock_running_system = IntegrationTestSetup::new(n_accounts).await;
+    let mock_running_system = IntegrationTestSetup::new_for_account_contracts([
+        FeatureContract::AccountWithoutValidations(CairoVersion::Cairo0),
+        FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1),
+    ])
+    .await;
 
     let mut expected_tx_hashes = Vec::new();
     expected_tx_hashes


### PR DESCRIPTION
Make `spawn_test_rpc_state_reader` get an iterator of accounts and have count the number of occurrences by itself, instead of getting specific numbers per account.

To keep the diff small, the map of contract->n_instances_of_contract is cast back to the old type immediately.
Subsequent PRs will remove this cast and make the whole flow use the map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/454)
<!-- Reviewable:end -->
