### PR TITLE
refactor: move deploy_account_tx next to peers

### DIFF
--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -119,6 +119,15 @@ pub fn invoke_tx(cairo_version: CairoVersion) -> RPCTransaction {
         .generate_default_invoke()
 }
 
+//  TODO(Yael 18/6/2024): Get a final decision from product whether to support Cairo0.
+pub fn deploy_account_tx() -> RPCTransaction {
+    let default_account = FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1);
+
+    MultiAccountTransactionGenerator::new_for_account_contracts([default_account])
+        .account_with_id(0)
+        .generate_default_deploy_account()
+}
+
 // TODO: when moving this to Starknet API crate, move this const into a module alongside
 // MultiAcconutTransactionGenerator.
 type AccountId = u16;
@@ -470,15 +479,6 @@ pub fn external_tx_to_json(tx: &RPCTransaction) -> String {
 
     // Serialize back to pretty JSON string
     to_string_pretty(&tx_json).expect("Failed to serialize transaction")
-}
-
-//  TODO(Yael 18/6/2024): Get a final decision from product whether to support Cairo0.
-pub fn deploy_account_tx() -> RPCTransaction {
-    let default_account = FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1);
-
-    MultiAccountTransactionGenerator::new_for_account_contracts([default_account])
-        .account_with_id(0)
-        .generate_default_deploy_account()
 }
 
 pub fn deployed_account_contract_address(deploy_tx: &RPCTransaction) -> ContractAddress {


### PR DESCRIPTION
Moved next to similar constructors `invoke_tx()` and `declare_tx()`.

NOTE: Only move, no internal changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/458)
<!-- Reviewable:end -->
