### PR TITLE
fix: fix e2e test by using tx generator

### DIFF
--- a/crates/tests-integration/tests/end_to_end_test.rs
+++ b/crates/tests-integration/tests/end_to_end_test.rs
@@ -1,29 +1,47 @@
 use blockifier::test_utils::contracts::FeatureContract;
 use blockifier::test_utils::CairoVersion;
-use mempool_test_utils::starknet_api_test_utils::{deploy_account_tx, invoke_tx};
 use starknet_api::transaction::TransactionHash;
-use starknet_mempool_integration_tests::integration_test_setup::IntegrationTestSetup;
+use starknet_mempool_integration_tests::integration_test_utils::setup_with_tx_generation;
 
 #[tokio::test]
 async fn test_end_to_end() {
-    let mock_running_system = IntegrationTestSetup::new_for_account_contracts([
-        FeatureContract::AccountWithoutValidations(CairoVersion::Cairo0),
+    // Setup.
+    let accounts = [
         FeatureContract::AccountWithoutValidations(CairoVersion::Cairo1),
-    ])
-    .await;
+        FeatureContract::AccountWithoutValidations(CairoVersion::Cairo0),
+    ];
+    let (mock_running_system, mut tx_generator) = setup_with_tx_generation(&accounts).await;
 
-    let mut expected_tx_hashes = Vec::new();
-    expected_tx_hashes
-        .push(mock_running_system.assert_add_tx_success(&invoke_tx(CairoVersion::Cairo0)).await);
-    expected_tx_hashes
-        .push(mock_running_system.assert_add_tx_success(&invoke_tx(CairoVersion::Cairo1)).await);
-    expected_tx_hashes.push(mock_running_system.assert_add_tx_success(&deploy_account_tx()).await);
+    let account0_deploy_nonce0 = &tx_generator.account_with_id(0).generate_default_deploy_account();
+    let account0_invoke_nonce1 = tx_generator.account_with_id(0).generate_default_invoke();
+    let account1_invoke_nonce0 = tx_generator.account_with_id(1).generate_default_invoke();
+    let account0_invoke_nonce2 = tx_generator.account_with_id(0).generate_default_invoke();
+
+    // Test.
+
+    let account0_deploy_nonce0_tx_hash =
+        mock_running_system.assert_add_tx_success(account0_deploy_nonce0).await;
+
+    mock_running_system.assert_add_tx_success(&account0_invoke_nonce1).await;
+
+    // FIXME: invoke with nonce0 shouldn't be possible, fix it, make this FAIL.
+    let account1_invoke_nonce0_tx_hash =
+        mock_running_system.assert_add_tx_success(&account1_invoke_nonce0).await;
+
+    mock_running_system.assert_add_tx_success(&account0_invoke_nonce2).await;
 
     let mempool_txs = mock_running_system.get_txs(4).await;
-    assert_eq!(mempool_txs.len(), 3);
-    let mut actual_tx_hashes: Vec<TransactionHash> =
-        mempool_txs.iter().map(|tx| tx.tx_hash).collect();
-    actual_tx_hashes.sort();
-    expected_tx_hashes.sort();
-    assert_eq!(expected_tx_hashes, actual_tx_hashes);
+
+    // Assert.
+
+    // Only the transactions with nonce 0 should be returned from the mempool,
+    // because we haven't merged queue-replenishment yet.
+    let expected_tx_hashes_from_get_txs =
+        [account1_invoke_nonce0_tx_hash, account0_deploy_nonce0_tx_hash];
+
+    // This assert should be replaced with 4 once queue-replenishment is merged, also add a tx hole
+    // at that point, and ensure the assert doesn't change due to that.
+    assert_eq!(mempool_txs.len(), 2);
+    let actual_tx_hashes: Vec<TransactionHash> = mempool_txs.iter().map(|tx| tx.tx_hash).collect();
+    assert_eq!(expected_tx_hashes_from_get_txs, *actual_tx_hashes);
 }


### PR DESCRIPTION
- Make e2e use tx generator txs, which track nonces.
- As a result, the test now reflects the way the mempool behaves at the moment, and so only nonce-0 txs are returned from get_txs.
- Once get_txs begin replenishing the queue when the queue gets exhausted, this test should be fixed as per the comment below.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/mempool/461)
<!-- Reviewable:end -->
