### PR TITLE
refactor: make acocunt id usize

### DIFF
--- a/crates/mempool_test_utils/src/starknet_api_test_utils.rs
+++ b/crates/mempool_test_utils/src/starknet_api_test_utils.rs
@@ -130,7 +130,7 @@ pub fn deploy_account_tx() -> RPCTransaction {
 
 // TODO: when moving this to Starknet API crate, move this const into a module alongside
 // MultiAcconutTransactionGenerator.
-type AccountId = u16;
+type AccountId = usize;
 
 /// Manages transaction generation for multiple pre-funded accounts, internally bumping nonces
 /// as needed.
@@ -217,7 +217,8 @@ impl<'a> AccountTransactionGenerator<'a> {
     // TODO: support more contracts, instead of this hardcoded type.
     pub fn test_contract_address(&mut self) -> ContractAddress {
         let cairo_version = self.generator.account_contracts[&self.account_id].cairo_version();
-        FeatureContract::TestContract(cairo_version).get_instance_address(self.account_id)
+        let account_id = u16::try_from(self.account_id).unwrap();
+        FeatureContract::TestContract(cairo_version).get_instance_address(account_id)
     }
 
     /// Generates an `RPCTransaction` with fully custom parameters.
@@ -233,8 +234,8 @@ impl<'a> AccountTransactionGenerator<'a> {
     }
 
     pub fn sender_address(&mut self) -> ContractAddress {
-        let account_id = self.account_id;
-        self.generator.account_contracts[&account_id].get_instance_address(account_id)
+        let account_id = u16::try_from(self.account_id).unwrap();
+        self.generator.account_contracts[&self.account_id].get_instance_address(account_id)
     }
 
     /// Retrieves the nonce for the current account, and __increments__ it internally.


### PR DESCRIPTION
This sets up the upcoming separation between account ids, which is a UX
artifact for users of the tx generator that represents an index (hence
usize) in the initialization array of accounts; and instance ids, which
is a u16 that is part of an implementation detail of `FeatureContract`s.
More on this in susequent PRs.

commit-id:60101a6e

---

**Stack**:
- #477
- #476 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*